### PR TITLE
Set File Encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,5 +83,6 @@
 	<properties>
 		<package>net.kaikk.mc.fr</package>
 		<developer>KaiNoMood</developer>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 </project>


### PR DESCRIPTION
Sets correct file encoding so that if building on Windows the following warning does not appear
```
[WARNING] File encoding has not been set, using platform encoding Cp1252, i.e. build is platform dependent!
[WARNING] Using platform encoding (Cp1252 actually) to copy filtered resources, i.e. build is platform dependent!
```